### PR TITLE
Use visibility as hidden instead clip property

### DIFF
--- a/src/components/Checkbox/Input.js
+++ b/src/components/Checkbox/Input.js
@@ -48,9 +48,8 @@ const Input = styled.input.attrs({
   padding: 0;
   margin: 0;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
   border: 0;
-  visibility: visible;
+  visibility: hidden;
   white-space: nowrap;
 
   + ${/* sc-selector */Box} {

--- a/src/components/RadioButton/Input.js
+++ b/src/components/RadioButton/Input.js
@@ -47,9 +47,8 @@ const Input = styled.input.attrs({
   padding: 0;
   margin: 0;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
   border: 0;
-  visibility: visible;
+  visibility: hidden;
   white-space: nowrap;
 
   + ${/* sc-selector */Circle} {


### PR DESCRIPTION
`clip` property is deprecated. ([Link](https://developer.mozilla.org/en-US/docs/Web/CSS/clip)).

Instead of using clip property, I have set `visibility: hidden `.