### PR TITLE
fix(gallery): call child component in gallery after gallery ref is set

### DIFF
--- a/src/components/Gallery/Gallery.js
+++ b/src/components/Gallery/Gallery.js
@@ -18,7 +18,7 @@ const GalleryContainer = styled.div`
 
 class Gallery extends Component {
   state = {
-    isGallleryRefSet: false,
+    isGalleryRefSet: false,
   }
 
   getChildContext() {
@@ -29,13 +29,13 @@ class Gallery extends Component {
 
   setGalleryRef = (ref) => {
     this.galleryRef = ref;
-    this.setState({ isGallleryRefSet: true });
+    this.setState({ isGalleryRefSet: true });
   }
 
   getGalleryRef = () => this.galleryRef
 
   render() {
-    const { isGallleryRefSet } = this.state;
+    const { isGalleryRefSet } = this.state;
     const {
       className,
       width,
@@ -53,7 +53,7 @@ class Gallery extends Component {
         innerRef={this.setGalleryRef}
       >
         {
-          isGallleryRefSet ? React.Children.map(children, (child) => (
+          isGalleryRefSet ? React.Children.map(children, (child) => (
             <Spacer key={child} margin={scrollDirection === 'horizontal' ? [0, 0.5, 0, 0] : [0, 0, 0.5, 0]}>
               <Flex display="inline-flex">
                 {child}

--- a/src/components/Gallery/Gallery.js
+++ b/src/components/Gallery/Gallery.js
@@ -17,6 +17,10 @@ const GalleryContainer = styled.div`
 `;
 
 class Gallery extends Component {
+  state = {
+    isGallleryRefSet: false,
+  }
+
   getChildContext() {
     return {
       getGalleryRef: this.getGalleryRef,
@@ -25,11 +29,13 @@ class Gallery extends Component {
 
   setGalleryRef = (ref) => {
     this.galleryRef = ref;
+    this.setState({ isGallleryRefSet: true });
   }
 
   getGalleryRef = () => this.galleryRef
 
   render() {
+    const { isGallleryRefSet } = this.state;
     const {
       className,
       width,
@@ -47,13 +53,13 @@ class Gallery extends Component {
         innerRef={this.setGalleryRef}
       >
         {
-          React.Children.map(children, (child) => (
-            <Spacer margin={scrollDirection === 'horizontal' ? [0, 0.5, 0, 0] : [0, 0, 0.5, 0]}>
+          isGallleryRefSet ? React.Children.map(children, (child) => (
+            <Spacer key={child} margin={scrollDirection === 'horizontal' ? [0, 0.5, 0, 0] : [0, 0, 0.5, 0]}>
               <Flex display="inline-flex">
                 {child}
               </Flex>
             </Spacer>
-          ))
+          )) : null
         }
       </GalleryContainer>
     );


### PR DESCRIPTION
setGalleryRef is called after child component mounted. setGalleryRef is setting ref of gallery component and passing it to child component to trigger scroll event. So setting a state called isGallleryRefSet when ref is available and calling child component after ref is set.