### PR TITLE
fix(Link): set text-decoration: none for links

### DIFF
--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 const Link = styled.a`
   color: ${(props) => props.theme.color.blue};
+  text-decoration: none;
 
   &:hover {
     color: ${(props) => props.theme.color.blueDark};


### PR DESCRIPTION
As per the design guidelines we don't have underlines for links, but this the default behaviour of link tags. So in this PR the `text-decoration` css property is set to `none`.