### PR TITLE
fix(Image): does not respect non px values

### DIFF
--- a/src/Image/web/Image.js
+++ b/src/Image/web/Image.js
@@ -6,9 +6,9 @@ import Img from './Img';
 
 class Image extends Component {
   static getCdnUrl(src = '', width = '', height = '') {
-    const digitPxRegex = /^d+(px)?$/;
-    const integerWidth = digitPxRegex.test(width) ? Number.parseInt(width, 10) : 'auto';
-    const integerHeight = digitPxRegex.test(height) ? Number.parseInt(height, 10) : 'auto';
+    const validUnitForCdn = /^d+(px)?$/;
+    const integerWidth = validUnitForCdn.test(width) ? Number.parseInt(width, 10) : 'auto';
+    const integerHeight = validUnitForCdn.test(height) ? Number.parseInt(height, 10) : 'auto';
     const searchParams = [
       `w=${integerWidth || ''}`,
       `h=${integerHeight || ''}`,
@@ -97,7 +97,7 @@ class Image extends Component {
           innerRef={this.setImageRef}
           src={imageSrc}
           alt={alt}
-          width={width || '100%'}
+          width={width}
           height={height}
           grayscale={grayscale}
           isLoaded={isLoaded}

--- a/src/Image/web/Image.js
+++ b/src/Image/web/Image.js
@@ -6,9 +6,9 @@ import Img from './Img';
 
 class Image extends Component {
   static getCdnUrl(src = '', width = '', height = '') {
-    const validUnitForCdn = /^d+(px)?$/;
-    const integerWidth = validUnitForCdn.test(width) ? Number.parseInt(width, 10) : 'auto';
-    const integerHeight = validUnitForCdn.test(height) ? Number.parseInt(height, 10) : 'auto';
+    const validCdnUnit = /^d+(px)?$/;
+    const integerWidth = validCdnUnit.test(width) ? Number.parseInt(width, 10) : 'auto';
+    const integerHeight = validCdnUnit.test(height) ? Number.parseInt(height, 10) : 'auto';
     const searchParams = [
       `w=${integerWidth || ''}`,
       `h=${integerHeight || ''}`,

--- a/src/Image/web/Image.js
+++ b/src/Image/web/Image.js
@@ -96,7 +96,7 @@ class Image extends Component {
           innerRef={this.setImageRef}
           src={imageSrc}
           alt={alt}
-          width={width}
+          width={width || '100%'}
           height={height}
           grayscale={grayscale}
           isLoaded={isLoaded}

--- a/src/Image/web/Image.js
+++ b/src/Image/web/Image.js
@@ -6,8 +6,9 @@ import Img from './Img';
 
 class Image extends Component {
   static getCdnUrl(src = '', width = '', height = '') {
-    const integerWidth = Number.parseInt(width, 10);
-    const integerHeight = Number.parseInt(height, 10);
+    const digitPxRegex = /^d+(px)?$/;
+    const integerWidth = digitPxRegex.test(width) ? Number.parseInt(width, 10) : 'auto';
+    const integerHeight = digitPxRegex.test(height) ? Number.parseInt(height, 10) : 'auto';
     const searchParams = [
       `w=${integerWidth || ''}`,
       `h=${integerHeight || ''}`,
@@ -115,8 +116,8 @@ Image.propTypes = {
   className: PropTypes.string,
   src: PropTypes.string.isRequired,
   alt: PropTypes.string.isRequired,
-  width: PropTypes.string,
-  height: PropTypes.string,
+  width: PropTypes.string.isRequired,
+  height: PropTypes.string.isRequired,
   grayscale: PropTypes.bool,
   shape: PropTypes.oneOf(['bluntEdged', 'sharpEdged', 'circular']),
   lazy: PropTypes.bool,
@@ -125,8 +126,6 @@ Image.propTypes = {
 
 Image.defaultProps = {
   className: '',
-  width: '',
-  height: '',
   grayscale: false,
   shape: 'sharpEdged',
   lazy: true,


### PR DESCRIPTION
We are parsing width 100px or 100% and in both case, w=100 will be send to cdn. Cdn will return you a image of 100px width and when this image is trying to fit in 100% width then Image will be blur coz image size is 100px return by cdn and we are stretching that image.

Solution:- Don't pass width for 100% width and component will take care and return image having width 100%  